### PR TITLE
Set `singlecpu` to `false` in cnc-ddraw config

### DIFF
--- a/ClientFiles/Resources/Compatibility/Configs/cnc-ddraw.ini
+++ b/ClientFiles/Resources/Compatibility/Configs/cnc-ddraw.ini
@@ -78,7 +78,8 @@ handlemouse=true
 accuratetimers=false
 
 ; Force CPU0 affinity, avoids crashes/freezing, *might* have a performance impact
-singlecpu=true
+; Note (2025-05-06): bugged in 'true', better to use 'false'
+singlecpu=false
 
 ; Windows API Hooking, Possible values: 0 = disabled, 1 = IAT Hooking, 2 = Microsoft Detours
 ; Note: Can be used to fix issues related to new features added by cnc-ddraw such as windowed mode or stretching


### PR DESCRIPTION
Quote from @Metadorius:

> @YR and probably @TS too, not sure of the others
apparently latest Win11 24H2 degrades performance of single processor affinity (assuming that's what singlecpu=true does in cnc-ddraw) and even produces freezes
DDrawCompat 0.6.0 fixes this, and for cnc-ddraw configs you have to put singlecpu=false in config