### PR TITLE
Remove chat components from skirmish lobby

### DIFF
--- a/ClientFiles/Resources/GameLobbyBase.ini
+++ b/ClientFiles/Resources/GameLobbyBase.ini
@@ -30,7 +30,6 @@ $CC15=btnPickRandomMap:XNAClientButton
 $CC16=tbMapSearch:XNASuggestionTextBox
 $CC17=PlayerExtraOptionsPanel:PlayerExtraOptionsPanel
 $CC18=lbChatMessages:ChatListBox
-$CC19=tbChatInput:XNAChatTextBox
 $CC20=panelBorderTop:XNAExtraPanel
 $CC21=panelBorderBottom:XNAExtraPanel
 $CC22=panelBorderLeft:XNAExtraPanel

--- a/ClientFiles/Resources/GameLobbyBase.ini
+++ b/ClientFiles/Resources/GameLobbyBase.ini
@@ -29,7 +29,6 @@ $CC14=lblGameModeSelect:XNALabel
 $CC15=btnPickRandomMap:XNAClientButton
 $CC16=tbMapSearch:XNASuggestionTextBox
 $CC17=PlayerExtraOptionsPanel:PlayerExtraOptionsPanel
-$CC18=lbChatMessages:ChatListBox
 $CC20=panelBorderTop:XNAExtraPanel
 $CC21=panelBorderBottom:XNAExtraPanel
 $CC22=panelBorderLeft:XNAExtraPanel

--- a/ClientFiles/Resources/MultiplayerGameLobby.ini
+++ b/ClientFiles/Resources/MultiplayerGameLobby.ini
@@ -19,6 +19,7 @@ TeamWidth=35	                ; def=46
 ; controls
 $CCMP00=btnLockGame:XNAClientButton
 $CCMP01=chkAutoReady:XNAClientCheckBox
+$CCMP02=tbChatInput:XNAChatTextBox
 
 [lbMapList]
 $Height=291

--- a/ClientFiles/Resources/MultiplayerGameLobby.ini
+++ b/ClientFiles/Resources/MultiplayerGameLobby.ini
@@ -20,6 +20,7 @@ TeamWidth=35	                ; def=46
 $CCMP00=btnLockGame:XNAClientButton
 $CCMP01=chkAutoReady:XNAClientCheckBox
 $CCMP02=tbChatInput:XNAChatTextBox
+$CCMP03=lbChatMessages:ChatListBox
 
 [lbMapList]
 $Height=291


### PR DESCRIPTION
Well, this component should not exist in Skirmish Lobby. Since [XNAUI v3.1.1](https://github.com/Rampastring/Rampastring.XNAUI/commit/f1995d550cb94cf8c4b12ae77af221e2471a882c), there is a chance that tbChatInput shows as a vertical bar in Skirmish Lobby (because it has a default height > 0 now) -- but the border in CnCNet YR/the mod base covers it so I didn't reproduce this display issue in CnCNet YR or the mod base. The screenshot below is from Mental Omega

Better to remove this tbChatInput from Skirmish Lobby anyhow, in case it causes some trouble in the future.

<img width="811" height="237" alt="图片" src="https://github.com/user-attachments/assets/febc9769-48d3-46d1-a924-673c5adfaceb" />

